### PR TITLE
Add abstract Collapsiblefield class

### DIFF
--- a/src/resources/elements/abstract/collapsiblefield.js
+++ b/src/resources/elements/abstract/collapsiblefield.js
@@ -1,0 +1,60 @@
+import {Field} from './field';
+
+/**
+ * Collapsiblefield is a {@link Field} that can be collapsed. Usually
+ * collapsible fields have one or more children.
+ */
+export class Collapsiblefield extends Field {
+  /**
+   * Whether or not the UI element should be collapsed (i.e. only show the title)
+   * @type {Boolean}
+   */
+  collapsed = false;
+  /**
+   * Whether or not collapsing this field should be allowed.
+   */
+  isCollapsible = true;
+
+  /**
+   * Called when a child of this field changes its collapsed status.
+   * @param  {Field}   field          The field that was collapsed/uncollapsed.
+   * @param  {Boolean} isNowCollapsed Whether or not the child is now collapsed.
+   */
+  childCollapseChanged(field, isNowCollapsed) {}
+
+  /**
+   * Toggle the collapse status of this field.
+   */
+  toggleCollapse() {
+    this.setCollapsed(!this.collapsed);
+  }
+
+  /**
+   * Set the collapse status of this field.
+   */
+  setCollapsed(collapsed) {
+    if (this.isCollapsible) {
+      this.collapsed = collapsed;
+      if (this.parent) {
+        this.parent.childCollapseChanged(this, this.collapsed);
+      }
+    }
+  }
+
+  /**
+   * @inheritdoc
+   * @param {Boolean} [args.collapsed]     Whether or not the UI element should
+   *                                       be collapsed by default.
+   * @param {Boolean} [args.isCollapsible] Whether or not this field should be
+   *                                       collapsible.
+   */
+  init(id = '', args = {}) {
+    args = Object.assign({
+      collapsed: false,
+      isCollapsible: true
+    }, args);
+    this.collapsed = args.collapsed;
+    this.isCollapsible = args.isCollapsible;
+    return super.init(id, args);
+  }
+}

--- a/src/resources/elements/abstract/field.js
+++ b/src/resources/elements/abstract/field.js
@@ -365,4 +365,9 @@ export class Field {
     }
     return clone;
   }
+
+  // Functions implemented in Collapsiblefield.
+  setCollapsed() {}
+  toggleCollapse() {}
+  childCollapseChanged() {}
 }

--- a/src/resources/elements/abstract/parentfield.js
+++ b/src/resources/elements/abstract/parentfield.js
@@ -1,35 +1,20 @@
-import {Field} from './field';
+import {Collapsiblefield} from './collapsiblefield';
 
 /**
  * Parentfield is a {@link Field} with children.
  */
-export class Parentfield extends Field {
+export class Parentfield extends Collapsiblefield {
   /**
    * The internal storage for the children of this field.
    * @private
    */
   _children;
   /**
-   * Whether or not the UI element should be collapsed (i.e. only show the title)
+   * Whether or not to automatically collapse other fields when uncollapsing a
+   * field.
    * @type {Boolean}
    */
-  collapsed = false;
-  isCollapsible = true;
-
-  childCollapseChanged(field, isNowCollapsed) {}
-
-  toggleCollapse() {
-    if (this.isCollapsible) {
-      this.setCollapsed(!this.collapsed);
-    }
-  }
-
-  setCollapsed(collapsed) {
-    this.collapsed = collapsed;
-    if (this.parent) {
-      this.parent.childCollapseChanged(this, this.collapsed);
-    }
-  }
+  collapseManagement = false;
 
   /**
    * Get the children of this field as an array.
@@ -87,5 +72,34 @@ export class Parentfield extends Field {
       return elem.resolvePath(path.splice(1));
     }
     return undefined;
+  }
+
+  /**
+   * @inheritdoc
+   * @param {Boolean} [args.collapseManagement] Whether or not to automatically
+   *                                            collapse other fields when
+   *                                            uncollapsing a field.
+   */
+  init(id = '', args = {}) {
+    args = Object.assign({}, {
+      collapseManagement: true
+    });
+    this.collapseManagement = args.collapseManagement;
+    return super.init(id, args);
+  }
+
+  /**
+   * @inheritdoc
+   *
+   * This handles collapse management.
+   */
+  childCollapseChanged(field, isNowCollapsed) {
+    if (!isNowCollapsed && this.collapseManagement) {
+      for (const child of this._children) {
+        if (child !== field) {
+          child.setCollapsed(true);
+        }
+      }
+    }
   }
 }

--- a/src/resources/elements/abstract/parentfield.js
+++ b/src/resources/elements/abstract/parentfield.js
@@ -82,7 +82,7 @@ export class Parentfield extends Collapsiblefield {
    */
   init(id = '', args = {}) {
     args = Object.assign({
-      collapseManagement: true
+      collapseManagement: false
     }, args);
     this.collapseManagement = args.collapseManagement;
     return super.init(id, args);

--- a/src/resources/elements/abstract/parentfield.js
+++ b/src/resources/elements/abstract/parentfield.js
@@ -81,9 +81,9 @@ export class Parentfield extends Collapsiblefield {
    *                                            uncollapsing a field.
    */
   init(id = '', args = {}) {
-    args = Object.assign({}, {
+    args = Object.assign({
       collapseManagement: true
-    });
+    }, args);
     this.collapseManagement = args.collapseManagement;
     return super.init(id, args);
   }

--- a/src/resources/elements/arrayfield.js
+++ b/src/resources/elements/arrayfield.js
@@ -35,12 +35,6 @@ export class Arrayfield extends Parentfield {
    * @type {Boolean}
    */
   addIndexToChildLabel = true;
-  /**
-   * Whether or not to automatically collapse other fields when uncollapsing a
-   * field.
-   * @type {Boolean}
-   */
-  collapseManagement = false;
   /** @inheritdoc */
   _children = [];
 
@@ -57,9 +51,6 @@ export class Arrayfield extends Parentfield {
    *                                     {@link #format} is {@linkplain map}.
    *                                     This field is optional. By default, the
    *                                     whole value will be used as-is.
-   * @param {Boolean} [args.collapsed]   Whether or not the UI element should be
-   *                                     collapsed.
-   * @param {Boolean} [args.isCollapsible] Set to false to disable collapsing.
    */
   init(id = '', args = {}) {
     args = Object.assign({
@@ -67,19 +58,13 @@ export class Arrayfield extends Parentfield {
       newItemText: undefined,
       keyField: '_key',
       valueField: undefined,
-      addIndexToChildLabel: true,
-      collapseManagement: false,
-      collapsed: false,
-      isCollapsible: true
+      addIndexToChildLabel: true
     }, args);
     this.item = args.item;
     this.newItemText = args.newItemText;
     this.keyField = args.keyField;
     this.valueField = args.valueField;
     this.addIndexToChildLabel = args.addIndexToChildLabel;
-    this.collapseManagement = args.collapseManagement;
-    this.collapsed = args.collapsed;
-    this.isCollapsible = args.isCollapsible;
     return super.init(id, args);
   }
 
@@ -133,16 +118,6 @@ export class Arrayfield extends Parentfield {
       }
     }
     return value;
-  }
-
-  childCollapseChanged(field, isNowCollapsed) {
-    if (!isNowCollapsed && this.collapseManagement) {
-      for (const child of this._children) {
-        if (child !== field) {
-          child.setCollapsed(true);
-        }
-      }
-    }
   }
 
   /**

--- a/src/resources/elements/objectfield.js
+++ b/src/resources/elements/objectfield.js
@@ -21,11 +21,9 @@ export class Objectfield extends Parentfield {
 
   /** @inheritdoc */
   init(id = '', args = {}) {
-    args = Object.assign({children: {}, collapsed: false, isCollapsible: true, legendChildren: undefined}, args);
+    args = Object.assign({children: {}, legendChildren: undefined}, args);
     this._children = args.children;
-    this.collapsed = args.collapsed;
     this.legendChildren = args.legendChildren;
-    this.isCollapsible = args.isCollapsible;
     return super.init(id, args);
   }
 

--- a/src/resources/elements/typefield.js
+++ b/src/resources/elements/typefield.js
@@ -1,5 +1,5 @@
 import {containerless, bindable} from 'aurelia-framework';
-import {Field} from './abstract/field';
+import {Collapsiblefield} from './abstract/collapsiblefield';
 import {parseJSON} from '../jsonparser';
 
 /**
@@ -10,7 +10,7 @@ import {parseJSON} from '../jsonparser';
  * evaluation and supports $refs in type options.
  */
 @containerless
-export class Typefield extends Field {
+export class Typefield extends Collapsiblefield {
   /**
    * The type that is currently selected.
    * @type {String}
@@ -66,29 +66,6 @@ export class Typefield extends Field {
    * @type {Object}
    */
   types = {};
-  /**
-   * Whether or not the UI element should be collapsed (i.e. only show the title)
-   * @type {Boolean}
-   */
-  collapsed = false;
-  isCollapsible = true;
-
-  /*
-   * Called by child fields when they are collapsed/uncollapsed.
-   * Unused in Typefields, currently only used in Arrayfields.
-   */
-  childCollapseChanged(field, isNowCollapsed) {}
-
-  toggleCollapse() {
-    this.setCollapsed(!this.collapsed);
-  }
-
-  setCollapsed(collapsed) {
-    this.collapsed = collapsed;
-    if (this.parent) {
-      this.parent.childCollapseChanged(this, this.collapsed);
-    }
-  }
 
   /**
    * @inheritdoc
@@ -101,12 +78,9 @@ export class Typefield extends Field {
    * @param {Object} [args.types]    The schemas for the available types.
    * @param {Boolean} [args.copyValue] Whether or not to copy the value over to
    *                                   the new child when switching types.
-   * @param {Boolean} [args.collapsed] Whether or not to make the UI field be
-   *                                   collapsed by default.
    * @param {String} [args.keyPlaceholder] The UI placeholder for the key form field.
    * @param {String} [args.selectedType]   The type that should be selected by
    *                                       default.
-   * @param {Boolean} [args.isCollapsible] Set to false to disable collapsing.
    */
   init(id = '', args = {}) {
     args = Object.assign({
@@ -116,8 +90,6 @@ export class Typefield extends Field {
       keyKey: '',
       keyPlaceholder: 'Object key...',
       copyValue: false,
-      collapsed: false,
-      isCollapsible: true,
       types: { 'null': { 'type': 'text' } }
     }, args);
     this.types = args.types;
@@ -126,8 +98,6 @@ export class Typefield extends Field {
     this.keyKey = args.keyKey;
     this.keyPlaceholder = args.keyPlaceholder;
     this.copyValue = args.copyValue;
-    this.collapsed = args.collapsed;
-    this.isCollapsible = args.isCollapsible;
     this.defaultType = args.defaultType;
     this.setType(args.defaultType || Object.keys(this.types)[0]);
     return super.init(id, args);


### PR DESCRIPTION
Fixes #140 

This pull request adds an abstract `Collapsiblefield` class and makes `Parentfield` and `Typefield` extend that class. This pull request also moves collapse management code from `Arrayfield` to `Parentfield`