### PR TITLE
Hide empty values by default

### DIFF
--- a/src/resources/elements/abstract/field.js
+++ b/src/resources/elements/abstract/field.js
@@ -73,7 +73,7 @@ export class Field {
    * when it's empty.
    * @type {Boolean}
    */
-  hideValueIfEmpty = false
+  hideValueIfEmpty = true
   /**
    * Whether or not this field has the field {@link #collapsed} and the method
    * {@link #toggleCollapse()}
@@ -116,7 +116,7 @@ export class Field {
       helpText: '',
       conditions: {},
       showValueInParent: true,
-      hideValueIfEmpty: false
+      hideValueIfEmpty: true
     }, args);
     this.id = id;
     this.format = args.format;

--- a/src/schemas/security.js
+++ b/src/schemas/security.js
@@ -8,11 +8,13 @@ export const securityRequirements = {
     'label': 'Requirements Object',
     'item': {
       'label': 'Security Requirement',
+      'hideValueIfEmpty': false,
       'type': 'object',
       'children': {
         'name': {
           'type': 'option',
           'format': 'dropdown',
+          'hideIfNoChoices': false,
           'dataSources': [{
             'source': '/global-security/definitions',
             'key': '${#:key}'
@@ -20,6 +22,7 @@ export const securityRequirements = {
         },
         'scopes': {
           'type': 'array',
+          'hideValueIfEmpty': false,
           'item': {
             'type': 'text',
             'label': 'OAuth2 scope'


### PR DESCRIPTION
Fixes #205

This pull request hides empty values by default to reduce cluttering. This may break the spec, so before merging we should thoroughly check everything.