### PR TITLE
Fix Arrayfield.setValue() when using a custom valueField

### DIFF
--- a/src/resources/elements/arrayfield.js
+++ b/src/resources/elements/arrayfield.js
@@ -127,9 +127,12 @@ export class Arrayfield extends Parentfield {
    */
   setValue(value) {
     this._children = [];
-    for (const [key, item] of Object.entries(value)) {
+    for (let [key, item] of Object.entries(value)) {
       const index = this.addChild();
       if (this.format === 'map') {
+        if (this.valueField) {
+          item = { [this.valueField]: item };
+        }
         item[this.keyField] = key;
       }
       this._children[index].setValue(item);


### PR DESCRIPTION
Fixes #202

This pull request fixes `Arrayfield` `setValue()` calls when the `Arrayfield` has a custom field from where to get the value of the map entries. This is most likely what was causing the data corruption crash in #202.
