### PR TITLE
Fix reference dropdowns in certain cases

### DIFF
--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -119,7 +119,10 @@
           }
         },
         "reference": {
-          "label": "Target"
+          "label": "Target",
+          "choices": {
+            "choose": "Choose a target type..."
+          }
         }
       }
     },
@@ -191,7 +194,10 @@
           "item": {
             "label": "Security Requirement #{{index}}",
             "name": {
-              "label": "Name"
+              "label": "Name",
+              "choices": {
+                "choose": "Choose a security definition..."
+              }
             },
             "scopes": {
               "label": "Scopes",
@@ -316,13 +322,19 @@
         "label": "Response body"
       },
       "$ref": {
-        "label": "Target"
+        "label": "Target",
+        "choices": {
+          "choose": "Choose a target Response..."
+        }
       }
     },
     "parameter": {
       "label": "Parameter #{{index}}: {{-name}}",
       "$ref": {
-        "label": "Target"
+        "label": "Target",
+        "choices": {
+          "choose": "Choose a target Parameter..."
+        }
       },
       "name": {
         "label": "Name"
@@ -394,7 +406,10 @@
           "placeholder": "Enter key..."
         },
         "$ref": {
-          "label": "Target"
+          "label": "Target",
+          "choices": {
+            "choose": "Choose a target type..."
+          }
         },
         "title": {
           "label": "Title"

--- a/src/resources/elements/optionfield.js
+++ b/src/resources/elements/optionfield.js
@@ -83,7 +83,8 @@ export class Optionfield extends Field {
         });
       }
     }
-    if (this.choices.length === 0 && this.dataSources.length === 0) {
+    this.dataSources = args.dataSources;
+    if (this.format === 'checkbox' && this.choices.length === 0 && this.dataSources.length === 0) {
       // We don't want to leave the choices empty, so if there are no choices,
       // make a checkbox with no label.
       this.choices.push({
@@ -95,7 +96,6 @@ export class Optionfield extends Field {
       });
       this.checkboxFormat = 'simple';
     }
-    this.dataSources = args.dataSources;
     return super.init(id, args);
   }
 

--- a/src/schemas/parameters.js
+++ b/src/schemas/parameters.js
@@ -170,6 +170,10 @@ export const parameter = {
           'format': 'dropdown',
           'label': 'Target',
           'hideIfNoChoices': false,
+          'choices': [{
+            'key': '',
+            'i18nKey': 'choose'
+          }],
           'dataSources': [{
             'source': '/global-definitions/parameters',
             'key': '#/parameters/${#:key}',

--- a/src/schemas/responses.js
+++ b/src/schemas/responses.js
@@ -48,6 +48,10 @@ export const response = {
           'format': 'dropdown',
           'label': 'Target',
           'hideIfNoChoices': false,
+          'choices': [{
+            'key': '',
+            'i18nKey': 'choose'
+          }],
           'dataSources': [{
             'source': '/global-definitions/responses',
             'key': '#/responses/${#:key}',

--- a/src/schemas/security.js
+++ b/src/schemas/security.js
@@ -18,6 +18,10 @@ export const securityRequirements = {
           'type': 'option',
           'format': 'dropdown',
           'hideIfNoChoices': false,
+          'choices': [{
+            'key': '',
+            'i18nKey': 'choose'
+          }],
           'dataSources': [{
             'source': '/global-security/definitions',
             'key': '${#:key}'

--- a/src/schemas/types.js
+++ b/src/schemas/types.js
@@ -192,6 +192,10 @@ export const types = {
         'format': 'dropdown',
         'label': 'Target',
         'hideIfNoChoices': false,
+        'choices': [{
+          'key': '',
+          'i18nKey': 'choose'
+        }],
         'dataSources': [{
           'source': '/global-definitions/types',
           'key': '#/definitions/${#/name}',


### PR DESCRIPTION
Closes #177 

Create a field that has a `$ref` with a datasource dropdown when there is no data at the data source. Then create some data at the source. In this case, the value of the dropdown didn't update automatically (even though the label did).
This pull request adds a placeholder value for the dropdown so the user is forced to choose the value manually which circumvents the bug.

Demo available at https://dev.openapi.design/feature/fix-security-dropdown