### PR TITLE
Fix dropdown optionfields on IE

### DIFF
--- a/src/resources/elements/optionfield-dropdown-ie.html
+++ b/src/resources/elements/optionfield-dropdown-ie.html
@@ -1,0 +1,17 @@
+<template>
+  <div class="dropdown option field c${columns} columns" if.bind="display">
+    <label for.bind="id">
+      ${label}
+      <tooltip if.bind="helpText" text.bind="helpText">
+        <img src="res/info.svg" alt="Info"/>
+      </tooltip>
+    </label>
+    <select value.bind="selectedChoice" id.bind="id">
+      <!-- Dropdowns break on IE if we have if.bind, so we don't. -->
+      <option
+        repeat.for="choice of allChoices"
+        model.bind="choice.key"
+      >${choice.label}</option>
+    </select>
+  </div>
+</template>

--- a/src/resources/elements/optionfield.js
+++ b/src/resources/elements/optionfield.js
@@ -296,6 +296,10 @@ export class Optionfield extends Field {
    * @private
    */
   getViewStrategy() {
+    // Dropdowns break on IE, so we have a separate HTML file for IE.
+    if (!!document.documentMode && this.format === 'dropdown') {
+      return `resources/elements/optionfield-${this.format}-ie.html`;
+    }
     return `resources/elements/optionfield-${this.format}.html`;
   }
 }


### PR DESCRIPTION
Fixes #226 

We weren't able to find any way to make the option conditions work properly on IE, so this pull request removes condition support from `Optionfield` options when using IE. Removing condition support will cause some options to display when they're not needed/allowed, but they should still be usable.