### PR TITLE
Move all condition checking to static Field functions

### DIFF
--- a/src/resources/elements/abstract/field.js
+++ b/src/resources/elements/abstract/field.js
@@ -258,7 +258,7 @@ export class Field {
    * @return {Boolean}                   Whether or not ALL the conditions were
    *                                     fulfilled.
    */
-  static checkConditions(conditions, parentField = this) {
+  static checkConditions(conditions, parentField) {
     for (const [fieldPath, expectedValue] of Object.entries(conditions)) {
       if (!Field.checkCondition(fieldPath, expectedValue, parentField)) {
         return false;
@@ -291,7 +291,10 @@ export class Field {
    * @return {Boolean}                   Whether or not the field at the given
    *                                     path has the given value.
    */
-  static checkCondition(fieldPath, expectedValue, parentField = this) {
+  static checkCondition(fieldPath, expectedValue, parentField) {
+    if (!parentField) {
+      return false;
+    }
     const field = parentField.resolveRef(fieldPath);
     if (!field) {
       return false;
@@ -315,7 +318,7 @@ export class Field {
    * Check whether or not this field should be displayed.
    */
   shouldDisplay() {
-    return Field.checkConditions(this.conditions);
+    return Field.checkConditions(this.conditions, this);
   }
 
   /**

--- a/src/resources/elements/abstract/field.js
+++ b/src/resources/elements/abstract/field.js
@@ -259,6 +259,9 @@ export class Field {
    *                                     fulfilled.
    */
   static checkConditions(conditions, parentField) {
+    if (!conditions) {
+      return true;
+    }
     for (const [fieldPath, expectedValue] of Object.entries(conditions)) {
       if (!Field.checkCondition(fieldPath, expectedValue, parentField)) {
         return false;

--- a/src/resources/elements/abstract/field.js
+++ b/src/resources/elements/abstract/field.js
@@ -247,27 +247,75 @@ export class Field {
   }
 
   /**
-   * Check whether or not this field should be displayed.
+   * Check a list of conditions. Uses {@link Field#checkCondition} for checking
+   * the single conditions.
+   *
+   * @param  {Object} conditions         The conditions. The key is the path to
+   *                                     the field and the value is the expected
+   *                                     value of that field.
+   * @param  {Field}  [parentField=this] The field to use for resolving field
+   *                                     paths.
+   * @return {Boolean}                   Whether or not ALL the conditions were
+   *                                     fulfilled.
    */
-  shouldDisplay() {
-    for (const [path, value] of Object.entries(this.conditions)) {
-      const elem = this.resolveRef(path);
-
-      if (!elem) {
-        return false;
-      }
-
-      const elemValue = elem.getValue();
-
-      if (Array.isArray(value)) {
-        if (!value.includes(elemValue)) {
-          return false;
-        }
-      } else if (value !== elemValue) {
+  static checkConditions(conditions, parentField = this) {
+    for (const [fieldPath, expectedValue] of Object.entries(conditions)) {
+      if (!Field.checkCondition(fieldPath, expectedValue, parentField)) {
         return false;
       }
     }
     return true;
+  }
+
+  /**
+   * Check that the field at the given path has a certain value.
+   *
+   * If the expected value is undefined, this will check if the value of the
+   * field is defined.
+   * If the value of the field is an array, but the expected value is not, this
+   * will check if the field value contains the expected value.
+   * If the value of the field is NOT an array, but the expected value is, this
+   * will check if the expected value contains the field value.
+   *
+   * If the expected value is a function, this will return the value of that
+   * function when called with the field value as a parameter.
+   *
+   * If none of the cases above happen, this will return
+   * {@linkplain expectedValue === fieldValue}
+   *
+   * @param  {String} fieldPath          The path to the field whose value to
+   *                                     check. Relative to {@linkplain parentField}.
+   * @param  {Field}  expectedValue      The expected value of the field.
+   * @param  {Field}  [parentField=this] The field to use for resolving
+   *                                     {@linkplain fieldPath}.
+   * @return {Boolean}                   Whether or not the field at the given
+   *                                     path has the given value.
+   */
+  static checkCondition(fieldPath, expectedValue, parentField = this) {
+    const field = parentField.resolveRef(fieldPath);
+    if (!field) {
+      return false;
+    }
+    const fieldValue = field.getValue();
+    if (expectedValue === undefined || expectedValue === null) {
+      return fieldValue !== undefined && fieldValue !== null;
+    } else if (Array.isArray(expectedValue) && !Array.isArray(fieldValue)) {
+      return expectedValue.includes(fieldValue);
+    } else if (!Array.isArray(expectedValue) && Array.isArray(fieldValue)) {
+      return fieldValue.includes(expectedValue);
+    } else if (typeof expectedValue === 'function') {
+      return expectedValue(fieldValue);
+    } else if (typeof expectedValue !== 'object') {
+      return expectedValue === fieldValue;
+    }
+    return false;
+  }
+
+  /**
+   * Check whether or not this field should be displayed.
+   */
+  shouldDisplay() {
+    return Field.checkConditions(this.conditions);
   }
 
   /**

--- a/src/resources/elements/optionfield.js
+++ b/src/resources/elements/optionfield.js
@@ -78,7 +78,7 @@ export class Optionfield extends Field {
           // The HTML templates can't do this complex logic, so we have to do it
           // here.
           get conditionsFulfilled() {
-            return Optionfield.conditionsFulfilled(choice.conditions, choiceParent);
+            return Field.checkConditions(choice.conditions, choiceParent);
           }
         });
       }
@@ -133,8 +133,8 @@ export class Optionfield extends Field {
             key: child.formatReferencePlusField(dataSource.key),
             selected: false,
             get conditionsFulfilled() {
-              return Optionfield.conditionsFulfilled(dataSource.localConditions, target)
-                  && Optionfield.conditionsFulfilled(dataSource.targetConditions, target);
+              return Field.checkConditions(dataSource.localConditions, target)
+                  && Field.checkConditions(dataSource.targetConditions, target);
             }
           };
           if (dataSource.label) {
@@ -161,21 +161,6 @@ export class Optionfield extends Field {
       }
     }
     return false;
-  }
-
-  static conditionsFulfilled(conditions, parentField) {
-    if (conditions) {
-      for (const [fieldPath, expectedValue] of Object.entries(conditions)) {
-        const field = parentField.resolveRef(fieldPath);
-        const value = field ? field.getValue() : undefined;
-        if (Array.isArray(value) && !value.includes(expectedValue)) {
-          return false;
-        } else if (value !== expectedValue) {
-          return false;
-        }
-      }
-    }
-    return true;
   }
 
   get allChoices() {


### PR DESCRIPTION
Currently condition checking is separately implemented in `Field.shouldDisplay()` and `Optionfield.conditionsFulfilled()`. This pull request creates a unified `Field.checkConditions()` implementation and changes all condition checks to use that function.