### PR TITLE
Add option to disable split view

### DIFF
--- a/res/split.svg
+++ b/res/split.svg
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- From https://github.com/encharm/Font-Awesome-SVG-PNG/blob/master/black/svg/columns.svg -->
+<svg width="1792" height="1792" viewBox="0 0 1792 1792" xmlns="http://www.w3.org/2000/svg">
+	<path d="M224 1536h608v-1152h-640v1120q0 13 9.5 22.5t22.5 9.5zm1376-32v-1120h-640v1152h608q13 0 22.5-9.5t9.5-22.5zm128-1216v1216q0 66-47 113t-113 47h-1344q-66 0-113-47t-47-113v-1216q0-66 47-113t113-47h1344q66 0 113 47t47 113z"/>
+</svg>

--- a/src/app.js
+++ b/src/app.js
@@ -10,6 +10,7 @@ import $ from 'jquery';
 @inject(I18N, EventAggregator)
 export class App {
   constructor(i18n, ea) {
+    this.split(window.localStorage.split || 'both');
     Field.internationalizer = i18n;
     Field.eventAggregator = ea;
     // Allow access from browser console
@@ -48,6 +49,12 @@ export class App {
     };
 
     this.forms.addChangeListener(() => this.saveFormLocal());
+  }
+
+  split(type) {
+    this.showEditor = type !== 'preview';
+    this.showPreview = type !== 'editor';
+    window.localStorage.split = type;
   }
 
   attached() {

--- a/src/app.js
+++ b/src/app.js
@@ -54,6 +54,7 @@ export class App {
   split(type) {
     this.showEditor = type !== 'preview';
     this.showPreview = type !== 'editor';
+    this.showBoth = type === 'both';
     window.localStorage.split = type;
   }
 

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -11,6 +11,11 @@
       "definitions": "Definitions"
     },
     "actions": {
+      "split": {
+        "editor": "Editor only",
+        "both": "Split view",
+        "preview": "Preview only"
+      },
       "delete": "Delete data",
       "download": {
         "json": "JSON",

--- a/src/sections/main.html
+++ b/src/sections/main.html
@@ -1,7 +1,7 @@
 <template>
-	<div class="main" if.bind="activeForm">
-    <compose view="./about.html" containerless></compose>
-    <compose class="form" view-model.bind="activeForm" if.bind="activeForm !== 'about'"></compose>
-    <div class="preview" textcontent.one-way="currentFormJSON" if.bind="activeForm !== 'about'"></div>
+	<div class="main ${showEditor ? 'has-editor' : ''} ${showPreview ? 'has-preview' : ''}" if.bind="activeForm">
+    <compose view="./about.html" if.bind="showEditor" containerless></compose>
+    <compose class="form" view-model.bind="activeForm" if.bind="showEditor && activeForm !== 'about'"></compose>
+    <div class="preview" textcontent.one-way="currentFormJSON" if.bind="showPreview && activeForm !== 'about'"></div>
   </div>
 </template>

--- a/src/sections/main.html
+++ b/src/sections/main.html
@@ -1,6 +1,10 @@
 <template>
-	<div class="main ${showEditor ? 'has-editor' : ''} ${showPreview ? 'has-preview' : ''}" if.bind="activeForm">
-    <compose view="./about.html" if.bind="showEditor" containerless></compose>
+	<div class="main
+				${showEditor ? 'has-editor' : ''}
+				${showPreview ? 'has-preview' : ''}
+				${showBoth ? 'has-both' : ''}"
+			if.bind="activeForm">
+    <compose view="./about.html" containerless></compose>
     <compose class="form" view-model.bind="activeForm" if.bind="showEditor && activeForm !== 'about'"></compose>
     <div class="preview" textcontent.one-way="currentFormJSON" if.bind="showPreview && activeForm !== 'about'"></div>
   </div>

--- a/src/sections/navbar.html
+++ b/src/sections/navbar.html
@@ -23,6 +23,22 @@
     </a>
 
     <div class="actions">
+      <div class="split dropdown">
+        <button class="button">
+          <img src="res/split.svg" alt="Delete"/>
+        </button>
+        <div class="content">
+          <a href="javascript:void(0)" click.delegate="split('editor')" t="nav.actions.split.editor">
+						Editor only
+					</a>
+          <a href="javascript:void(0)" click.delegate="split('both')" t="nav.actions.split.both">
+						Split view
+					</a>
+          <a href="javascript:void(0)" click.delegate="split('preview')" t="nav.actions.split.preview">
+						Preview only
+					</a>
+        </div>
+      </div>
       <div class="delete dropdown">
         <button class="button">
           <img src="res/trash.svg" alt="Delete"/>

--- a/src/sections/navbar.html
+++ b/src/sections/navbar.html
@@ -1,80 +1,82 @@
 <template>
-	<div class="nav" if.bind="activeForm">
-    <a class="nav-link open" t="nav.tab.about" id="nav-about" href="#/about">
-      About
-    </a>
-    <a class="nav-link" t="nav.tab.header" id="nav-header" href="#/header">
-      Header
-    </a>
-    <a class="nav-link" t="nav.tab.mime" id="nav-mime" href="#/mime">
-      MIME types
-    </a>
-    <a class="nav-link" t="nav.tab.security" id="nav-global-security" href="#/global-security">
-      Security
-    </a>
-    <a class="nav-link" t="nav.tab.tags" id="nav-tags" href="#/tags">
-      Tags
-    </a>
-    <a class="nav-link" t="nav.tab.paths" id="nav-paths" href="#/paths">
-      Paths
-    </a>
-    <a class="nav-link" t="nav.tab.definitions" id="nav-global-definitions" href="#/global-definitions">
-      Definitions
-    </a>
+	<div class="nav-wrapper ${showBoth ? '' : 'no-split-view'}" if.bind="activeForm">
+		<div class="nav">
+	    <a class="nav-link open" t="nav.tab.about" id="nav-about" href="#/about">
+	      About
+	    </a>
+	    <a class="nav-link" t="nav.tab.header" id="nav-header" href="#/header">
+	      Header
+	    </a>
+	    <a class="nav-link" t="nav.tab.mime" id="nav-mime" href="#/mime">
+	      MIME types
+	    </a>
+	    <a class="nav-link" t="nav.tab.security" id="nav-global-security" href="#/global-security">
+	      Security
+	    </a>
+	    <a class="nav-link" t="nav.tab.tags" id="nav-tags" href="#/tags">
+	      Tags
+	    </a>
+	    <a class="nav-link" t="nav.tab.paths" id="nav-paths" href="#/paths">
+	      Paths
+	    </a>
+	    <a class="nav-link" t="nav.tab.definitions" id="nav-global-definitions" href="#/global-definitions">
+	      Definitions
+	    </a>
 
-    <div class="actions">
-      <div class="split dropdown">
-        <button class="button">
-          <img src="res/split.svg" alt="Delete"/>
-        </button>
-        <div class="content">
-          <a href="javascript:void(0)" click.delegate="split('editor')" t="nav.actions.split.editor">
-						Editor only
-					</a>
-          <a href="javascript:void(0)" click.delegate="split('both')" t="nav.actions.split.both">
-						Split view
-					</a>
-          <a href="javascript:void(0)" click.delegate="split('preview')" t="nav.actions.split.preview">
-						Preview only
-					</a>
-        </div>
-      </div>
-      <div class="delete dropdown">
-        <button class="button">
-          <img src="res/trash.svg" alt="Delete"/>
-        </button>
-        <div class="content">
-          <a href="javascript:void(0)" click.delegate="delete()" t="nav.actions.delete">
-            Delete data
-          </a>
-        </div>
-      </div>
-      <div class="import dropdown">
-        <button class="button">
-          <img src="res/import.svg" alt="Import"/>
-        </button>
-        <div class="content">
-          <a href="javascript:void(0)" click.delegate="pasteModal.open()" t="nav.actions.import.paste">
-            Paste
-          </a>
-          <a href="javascript:void(0)" click.delegate="importFile()" t="nav.actions.import.file">
-            Choose file
-          </a>
-        </div>
-      </div>
-      <div class="download dropdown">
-        <button class="button">
-          <img src="res/download.svg" alt="Download"/>
-        </button>
-        <div class="content">
-          <a href="javascript:void(0)" click.delegate="download('json')" t="nav.actions.download.json">
-            JSON
-          </a>
-          <a href="javascript:void(0)" click.delegate="download('yaml')" t="nav.actions.download.yaml">
-            YAML
-          </a>
-        </div>
-      </div>
-    </div>
-  </div>
+	    <div class="actions">
+	      <div class="split dropdown">
+	        <button class="button">
+	          <img src="res/split.svg" alt="Delete"/>
+	        </button>
+	        <div class="content">
+	          <a href="javascript:void(0)" click.delegate="split('editor')" t="nav.actions.split.editor">
+							Editor only
+						</a>
+	          <a href="javascript:void(0)" click.delegate="split('both')" t="nav.actions.split.both">
+							Split view
+						</a>
+	          <a href="javascript:void(0)" click.delegate="split('preview')" t="nav.actions.split.preview">
+							Preview only
+						</a>
+	        </div>
+	      </div>
+	      <div class="delete dropdown">
+	        <button class="button">
+	          <img src="res/trash.svg" alt="Delete"/>
+	        </button>
+	        <div class="content">
+	          <a href="javascript:void(0)" click.delegate="delete()" t="nav.actions.delete">
+	            Delete data
+	          </a>
+	        </div>
+	      </div>
+	      <div class="import dropdown">
+	        <button class="button">
+	          <img src="res/import.svg" alt="Import"/>
+	        </button>
+	        <div class="content">
+	          <a href="javascript:void(0)" click.delegate="pasteModal.open()" t="nav.actions.import.paste">
+	            Paste
+	          </a>
+	          <a href="javascript:void(0)" click.delegate="importFile()" t="nav.actions.import.file">
+	            Choose file
+	          </a>
+	        </div>
+	      </div>
+	      <div class="download dropdown">
+	        <button class="button">
+	          <img src="res/download.svg" alt="Download"/>
+	        </button>
+	        <div class="content">
+	          <a href="javascript:void(0)" click.delegate="download('json')" t="nav.actions.download.json">
+	            JSON
+	          </a>
+	          <a href="javascript:void(0)" click.delegate="download('yaml')" t="nav.actions.download.yaml">
+	            YAML
+	          </a>
+	        </div>
+	      </div>
+	    </div>
+	  </div>
+	</div>
 </template>

--- a/src/style/_main.scss
+++ b/src/style/_main.scss
@@ -2,7 +2,8 @@
   margin: 1rem 1.5rem 5rem;
 
   &.has-preview:not(.has-editor) > .preview,
-      &.has-editor:not(.has-preview) > .form {
+      &.has-editor:not(.has-preview) > .form,
+      &:not(.has-both) > .about {
     display: block;
     float: none;
 

--- a/src/style/_main.scss
+++ b/src/style/_main.scss
@@ -1,12 +1,14 @@
 .main {
   margin: 1rem 1.5rem 5rem;
 
-  &.has-preview:not(.has-editor) > .preview {
-    width: 100%;
-  }
+  &.has-preview:not(.has-editor) > .preview,
+      &.has-editor:not(.has-preview) > .form {
+    display: block;
+    float: none;
 
-  &.has-editor:not(.has-preview) > .form {
     width: 100%;
+    max-width: 50rem;
+    margin: auto;
   }
 
   .form {

--- a/src/style/_main.scss
+++ b/src/style/_main.scss
@@ -1,6 +1,14 @@
 .main {
   margin: 1rem 1.5rem 5rem;
 
+  &.has-preview:not(.has-editor) > .preview {
+    width: 100%;
+  }
+
+  &.has-editor:not(.has-preview) > .form {
+    width: 100%;
+  }
+
   .form {
     display: inline-block;
 

--- a/src/style/_nav.scss
+++ b/src/style/_nav.scss
@@ -1,4 +1,4 @@
-.nav {
+.nav-wrapper {
   position: -webkit-sticky;
   position: sticky;
   top: 0;
@@ -8,6 +8,13 @@
   border-bottom: 1px solid lightgray;
   background-color: white;
 
+  &.no-split-view > .nav {
+    max-width: 50rem;
+    margin: auto;
+  }
+}
+
+.nav-wrapper > .nav {
   > .nav-link {
     display: inline;
 


### PR DESCRIPTION
Fixes #92 

This pull request adds a new option to only display the editor or the preview. If only one view is visible (non-split view), the navbar and the main view will be centered with a maximum width of `50rem`.

Demo available at https://dev.openapi.design/feature/split-view