### PR TITLE
Return number from number-format textfields

### DIFF
--- a/src/resources/elements/textfield.js
+++ b/src/resources/elements/textfield.js
@@ -62,9 +62,13 @@ export class Textfield extends Field {
 
   /**
    * @inheritdoc
-   * @return {String} The text in the input field.
+   * @return {String|Number} The text in the input field. Returns as a Number if
+   *                         the format has been set to number.
    */
   getValue() {
+    if (this.format === 'number') {
+      return +this.value;
+    }
     return this.value;
   }
 

--- a/src/schemas/types.js
+++ b/src/schemas/types.js
@@ -89,7 +89,30 @@ export const enumItem = {
   'isCollapsible': false,
   'typeKey': '',
   'setValueListeners': [
-    (field, newValue) => field.setType(typeof newValue)
+    (field, newValue) => {
+      if (!newValue) {
+        return;
+      }
+      switch (typeof newValue) {
+      case 'number':
+        if (Number.isInteger(newValue)) {
+          field.setType('integer');
+        } else {
+          field.setType('number');
+        }
+        break;
+      case 'object':
+        if (Array.isArray(newValue)) {
+          field.setType('array');
+        }
+        // falls through
+      case 'null':
+        field.setType('string');
+        break;
+      default:
+        field.setType(typeof newValue);
+      }
+    }
   ],
   'types': {
     'string': {


### PR DESCRIPTION
Fixes #231 

This pull request changes `Textfield.getValue()` to return a number if the `format` is `number`.