### PR TITLE
Delete form data before importing

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -70,6 +70,7 @@ export class App {
   }
 
   importFile() {
+    delete(true);
     const fileInput = $('<input/>', { type: 'file' });
     fileInput.css({display: 'none'});
     fileInput.appendTo('body');
@@ -140,12 +141,17 @@ export class App {
     }
   }
 
-  delete() {
-    let userInput = confirm('Do you want to delete locally cached form data? \nThis action can not be undone.');
-    if (userInput === true) {
-      delete localStorage['openapi-v2-design'];
-      location.reload();
+  delete(force) {
+    if (!force) {
+      const userInput = confirm('Do you want to delete locally cached form data? \nThis action can not be undone.');
+      if (!userInput) {
+        return;
+      }
     }
+    const pointerlessSchema = $.extend(true, {}, schema);
+    this.forms = parseJSON('form', pointerlessSchema);
+    delete localStorage['openapi-v2-design'];
+    window.onhashchange();
   }
 
   getFormData() {


### PR DESCRIPTION
Fixes #240 

This pull request updates the file importer to delete old data before importing a new file. This pull request also updates the `delete()` function to not require a refresh.
Deleting before importing also seems to speed up importing significantly. The cause of this is currently unknown.