### PR TITLE
Make branding narrow in non-split mode

### DIFF
--- a/src/sections/about.html
+++ b/src/sections/about.html
@@ -1,5 +1,5 @@
 <template>
-  <div class="about" if.bind="activeForm === 'about'">
+  <div class="about">
     <div class="about-inner">
       <img src="res/openapi-designer-logo-tall.png" style="width: 100%;"/>
 

--- a/src/sections/brand-footer.html
+++ b/src/sections/brand-footer.html
@@ -1,16 +1,18 @@
 <template>
-  <div class="brand-footer">
-    <div class="top-row">
-      <span class="product-of" t="footer-product-of">
-        Product of
-      </span>
-    </div>
-    <div class="bottom-row">
-      <select value.bind="language" class="language">
-        <option value="en">English</option>
-        <option value="fi">Suomi</option>
-      </select>
-      <img class="apinf-logo" src="res/apinf-logo.png"/>
+  <div class="brand-footer-wrapper">
+    <div class="brand-footer ${splitView ? 'split-view' : ''}">
+      <div class="top-row">
+        <span class="product-of" t="footer-product-of">
+          Product of
+        </span>
+      </div>
+      <div class="bottom-row">
+        <select value.bind="language" class="language">
+          <option value="en">English</option>
+          <option value="fi">Suomi</option>
+        </select>
+        <img class="apinf-logo" src="res/apinf-logo.png"/>
+      </div>
     </div>
   </div>
 </template>

--- a/src/sections/brand-header.html
+++ b/src/sections/brand-header.html
@@ -1,13 +1,15 @@
 <template>
-  <div class="brand-header">
-    <img class="logo" src="res/openapi-designer-logo.png"/>
-    <div class="right">
-      <a href="javascript:void(0)" click.delegate="infoModal.open()">
-        <img class="info" src="res/info-logo.svg"/>
-      </a>
-      <a href="https://github.com/apinf/open-api-designer">
-        <img class="github" src="res/github.svg"/>
-      </a>
+  <div class="brand-header-wrapper">
+    <div class="brand-header ${splitView ? 'split-view' : ''}">
+      <img class="logo" src="res/openapi-designer-logo.png"/>
+      <div class="right">
+        <a href="javascript:void(0)" click.delegate="infoModal.open()">
+          <img class="info" src="res/info-logo.svg"/>
+        </a>
+        <a href="https://github.com/apinf/open-api-designer">
+          <img class="github" src="res/github.svg"/>
+        </a>
+      </div>
     </div>
   </div>
 </template>

--- a/src/sections/main.html
+++ b/src/sections/main.html
@@ -4,7 +4,7 @@
         ${splitView ? 'split-view' : ''}
         ${showOutput ? 'has-output-editor' : ''}"
       if.bind="activeForm">
-    <compose view="./about.html" containerless></compose>
+    <compose view="./about.html" if.bind="showEditor && activeForm === 'about'" containerless></compose>
     <compose class="form" view-model.bind="activeForm" if.bind="showEditor && activeForm !== 'about'"></compose>
     <div class="preview" textcontent.one-way="currentFormJSON" if.bind="splitView && activeForm !== 'about'"></div>
     <div class="output-editor" if.bind="showOutput">

--- a/src/sections/navbar.html
+++ b/src/sections/navbar.html
@@ -1,5 +1,5 @@
 <template>
-  <div class="nav-wrapper ${splitView ? '' : 'no-split-view'}" if.bind="activeForm">
+  <div class="nav-wrapper ${splitView ? 'split-view' : ''}" if.bind="activeForm">
     <div class="nav">
       <div class="editor-nav nav-links" if.bind="!showOutput">
         <a class="nav-link open" t="nav.tab.about" id="nav-about" href="#/about">

--- a/src/style/_brand.scss
+++ b/src/style/_brand.scss
@@ -1,13 +1,20 @@
-.brand-header {
+.brand-header-wrapper {
   box-sizing: border-box;
   height: 3.5rem;
   margin-bottom: 1.5rem;
   padding: .5rem 1.5rem;
 
   background-color: black;
+}
+
+.brand-header {
+  &:not(.split-view) {
+    max-width: 60rem;
+    margin: 0 auto;
+  }
 
   .logo {
-    height: 40px;
+    height: 2.5rem;
   }
 
   .right {
@@ -16,8 +23,8 @@
     a {
       display: inline-block;
 
-      width: 32px;
-      height: 32px;
+      width: 2rem;
+      height: 2rem;
       padding: .25rem .5rem;
 
       img {
@@ -28,7 +35,7 @@
   }
 }
 
-.brand-footer {
+.brand-footer-wrapper {
   position: absolute;
   bottom: 0;
   left: 0;
@@ -40,6 +47,13 @@
   padding: .25rem 1.5rem;
 
   background-color: black;
+}
+
+.brand-footer {
+  &:not(.split-view) {
+    max-width: 60rem;
+    margin: 0 auto;
+  }
 
   .language {
     color: white;

--- a/src/style/_nav.scss
+++ b/src/style/_nav.scss
@@ -8,7 +8,7 @@
   border-bottom: 1px solid lightgray;
   background-color: white;
 
-  &.no-split-view > .nav {
+  &:not(.split-view) > .nav {
     max-width: 60rem;
     margin: auto;
   }


### PR DESCRIPTION
Fixes #249 

This pull request adds side margins to the brand header/footer content when in non-split mode. This pull request also improves the consistency of split view-related code and fixes a bug with the about page displaying on the editable output page.