### PR TITLE
Allow scrolling preview separately from the form in split view

### DIFF
--- a/src/style/_main.scss
+++ b/src/style/_main.scss
@@ -12,6 +12,23 @@
     margin: auto;
   }
 
+  &.split-view {
+    position: absolute;
+    top: 5.75rem;
+    right: 0;
+    bottom: 3.5rem;
+    left: 0;
+
+    margin: 1rem 1.5rem;
+
+    > .about, > .form, > .preview {
+      overflow-y: auto;
+
+      box-sizing: border-box;
+      height: 100%;
+    }
+  }
+
   .output-editor {
     textarea {
       width: 100%;

--- a/src/style/_nav.scss
+++ b/src/style/_nav.scss
@@ -12,6 +12,10 @@
     max-width: 60rem;
     margin: auto;
   }
+
+  &.split-view {
+    z-index: 10;
+  }
 }
 
 .nav-wrapper > .nav {


### PR DESCRIPTION
Fixes #43 

This pull request allows the user to scroll the editor and the preview separately from each other in the split view mode. This removes the problem that the user had no way of seeing the part in the preview being edited.