### PR TITLE
Add some margin-bottom to in-form navbars

### DIFF
--- a/src/style/_form.scss
+++ b/src/style/_form.scss
@@ -193,6 +193,7 @@
 
   &.tabbed.object {
     > .tabs {
+      margin-bottom: 1rem;
       padding: .5rem 1rem;
 
       border-bottom: 1px solid lightgray;


### PR DESCRIPTION
Fixes #272 

This pull request adds a bit of margin below navigation bars that are inside the main form.