### PR TITLE
 Add support for advanced schema fields

### DIFF
--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -66,6 +66,9 @@
         "placeholder": "e.g. http://example.com/docs"
       }
     },
+    "defaultValue": {
+      "label": "Default value"
+    },
     "enum": {
       "label": "Allowed values",
       "item": {

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -501,6 +501,9 @@
         "items": {
           "label": "Array item"
         },
+        "additionalProperties": {
+          "label": "Schema for additional properties"
+        },
         "properties": {
           "label": "Properties",
           "item": {
@@ -508,11 +511,11 @@
           }
         },
         "required": {
-          "label": "Required subfields",
+          "label": "Required properties",
           "item": {
-            "label": "Required field",
+            "label": "Required properties",
             "choices": {
-              "choose": "Choose a field..."
+              "choose": "Choose a property..."
             }
           }
         },

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -457,6 +457,13 @@
     "types": {
       "label": "Types",
       "newItemText": "New Type",
+      "allOf": {
+        "label": "Joined types",
+        "newItemText": "New joined type",
+        "item": {
+          "label": "Joined type #$index"
+        }
+      },
       "item": {
         "label": "Type #{{index}}: {{-name}}",
         "x-oad-type": {
@@ -469,6 +476,7 @@
             "array": "Array",
             "object": "Object",
             "reference": "Reference",
+            "allOf": "Joined types",
             "null": "Null",
             "file": "File"
           }

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -501,6 +501,9 @@
         "items": {
           "label": "Array item"
         },
+        "uniqueItems": {
+          "label": "Require items to be unique?"
+        },
         "additionalProperties": {
           "label": "Schema for additional properties"
         },

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -498,6 +498,10 @@
           "label": "Description",
           "placeholder": "Enter description..."
         },
+        "readOnly": {
+          "label": "Read-only?",
+          "helpText": "If checked, this property doesn't affect anything when sent from the client. Read-only fields should not be marked as required."
+        },
         "items": {
           "label": "Array item"
         },

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -461,7 +461,7 @@
         "label": "Joined types",
         "newItemText": "New joined type",
         "item": {
-          "label": "Joined type #$index"
+          "label": "Joined type #{{-index}}"
         }
       },
       "item": {

--- a/src/resources/elements/abstract/collapsiblefield.js
+++ b/src/resources/elements/abstract/collapsiblefield.js
@@ -32,10 +32,10 @@ export class Collapsiblefield extends Field {
   /**
    * Set the collapse status of this field.
    */
-  setCollapsed(collapsed) {
+  setCollapsed(collapsed, triggerChange = true) {
     if (this.isCollapsible) {
       this.collapsed = collapsed;
-      if (this.parent) {
+      if (this.parent && triggerChange) {
         this.parent.childCollapseChanged(this, this.collapsed);
       }
     }

--- a/src/resources/elements/abstract/field.js
+++ b/src/resources/elements/abstract/field.js
@@ -284,7 +284,9 @@ export class Field {
     this.hideValueIfEmpty = args.hideValueIfEmpty;
     this.setValueListeners = args.setValueListeners;
     this.i18n = args.i18n;
-    this.i18n.interpolations.index = '$index';
+    if (!this.i18n.interpolations.index) {
+      this.i18n.interpolations.index = '$index';
+    }
     this.validation = [];
     for (const funcID of args.validation) {
       const func = Field.validationFunctions[funcID];
@@ -435,6 +437,10 @@ export class Field {
     }
 
     return this.formatReferencePlusField(this.formatIndex(label));
+  }
+
+  get humanIndex() {
+    return this.index + 1;
   }
 
   /**

--- a/src/resources/elements/arrayfield.js
+++ b/src/resources/elements/arrayfield.js
@@ -132,7 +132,7 @@ export class Arrayfield extends Parentfield {
     this.onSetValue(value);
     this._children = [];
     for (let [key, item] of Object.entries(value)) {
-      const index = this.addChild();
+      const index = this.addChild(true);
       if (this.format === 'map') {
         if (this.valueField) {
           item = { [this.valueField]: item };
@@ -146,7 +146,7 @@ export class Arrayfield extends Parentfield {
   /**
    * Add a new blank child to this array.
    */
-  addChild() {
+  addChild(forceCollapse) {
     if (!(this.item instanceof Field)) {
       return;
     }
@@ -160,7 +160,9 @@ export class Arrayfield extends Parentfield {
       field.labelFormat = `${field.labelFormat} #$index`;
     }
     this._children.push(field);
-    if (this.collapseManagement) {
+    if (forceCollapse === true) {
+      field.collapsed = true;
+    } else if (this.collapseManagement) {
       field.setCollapsed(false);
     }
     this.onChange(field);

--- a/src/resources/elements/lazylinkfield.js
+++ b/src/resources/elements/lazylinkfield.js
@@ -33,7 +33,10 @@ export class LazyLinkfield extends Field {
    * Check if this link doesn't currently have a child or if the child is empty.
    */
   isEmpty() {
-    if (!this.child && !this.cachedValue) {
+    if (!this.child) {
+      if (this.cachedValue) {
+        return false;
+      }
       return true;
     }
     return this.child.isEmpty();

--- a/src/resources/elements/lazylinkfield.js
+++ b/src/resources/elements/lazylinkfield.js
@@ -36,6 +36,8 @@ export class LazyLinkfield extends Field {
    */
   isEmpty() {
     if (!this.child) {
+      // If not slightlyLessLazy, ignore the cached value and state that the
+      // field is empty. Otherwise, check the cached value first.
       return !this.slightlyLessLazy || !this.cachedValue;
     }
     return this.child.isEmpty();

--- a/src/resources/elements/lazylinkfield.js
+++ b/src/resources/elements/lazylinkfield.js
@@ -33,7 +33,7 @@ export class LazyLinkfield extends Field {
    * Check if this link doesn't currently have a child or if the child is empty.
    */
   isEmpty() {
-    if (!this.child) {
+    if (!this.child && !this.cachedValue) {
       return true;
     }
     return this.child.isEmpty();
@@ -152,7 +152,7 @@ export class LazyLinkfield extends Field {
    *                  {@link #resolveTarget} returns {@linkplain undefined}.
    */
   getValue() {
-    return this.child ? this.child.getValue() : undefined;
+    return this.child ? this.child.getValue() : this.cachedValue;
   }
 
   resolvePath(path) {

--- a/src/resources/elements/lazylinkfield.js
+++ b/src/resources/elements/lazylinkfield.js
@@ -119,11 +119,12 @@ export class LazyLinkfield extends Field {
     // appears, the child will be deleted. This is what makes this link field
     // lazy.
     const display = super.shouldDisplay();
-    if (display) {
+    if (display && (!this.parent || !this.parent.isCollapsible || !this.parent.collapsed)) {
       if (this.child === undefined) {
         this.createChild();
       }
     } else if (this.child !== undefined) {
+      this.cachedValue = this.child.getValue();
       this.deleteChild();
     }
     return display;

--- a/src/resources/elements/lazylinkfield.js
+++ b/src/resources/elements/lazylinkfield.js
@@ -36,7 +36,7 @@ export class LazyLinkfield extends Field {
    */
   isEmpty() {
     if (!this.child) {
-      return this.slightlyLessLazy && !this.cachedValue;
+      return !this.slightlyLessLazy || !this.cachedValue;
     }
     return this.child.isEmpty();
   }

--- a/src/resources/elements/lazylinkfield.js
+++ b/src/resources/elements/lazylinkfield.js
@@ -12,11 +12,13 @@ export class LazyLinkfield extends Field {
   overrides = {};
   child = undefined;
   cachedValue = undefined;
+  slightlyLessLazy = false;
 
   /** @inheritdoc */
   init(id = '', args = {}) {
     this.target = args.target || '#';
     this.overrides = args.overrides || {};
+    this.slightlyLessLazy = !!args.slightlyLessLazy;
     return super.init(id, args);
   }
 
@@ -34,10 +36,7 @@ export class LazyLinkfield extends Field {
    */
   isEmpty() {
     if (!this.child) {
-      if (this.cachedValue) {
-        return false;
-      }
-      return true;
+      return this.slightlyLessLazy && !this.cachedValue;
     }
     return this.child.isEmpty();
   }
@@ -155,7 +154,12 @@ export class LazyLinkfield extends Field {
    *                  {@link #resolveTarget} returns {@linkplain undefined}.
    */
   getValue() {
-    return this.child ? this.child.getValue() : this.cachedValue;
+    if (this.child) {
+      return this.child.getValue();
+    } else if (this.slightlyLessLazy) {
+      return this.cachedValue;
+    }
+    return undefined;
   }
 
   resolvePath(path) {

--- a/src/schemas/index.js
+++ b/src/schemas/index.js
@@ -3,7 +3,7 @@ import {mime} from './mime';
 import {security} from './security';
 import {tags} from './tags';
 import {paths} from './paths';
-import {types, enumItem} from './types';
+import {types, enumItem, allOf} from './types';
 import {parameters, parameterItemDefinition} from './parameters';
 import {responses} from './responses';
 
@@ -45,6 +45,7 @@ export const schema = {
       }
     },
     'enum-item': enumItem,
+    'types-allof': allOf,
     'parameter-item-definition': hiddenParameterItemDefinition,
     'parameters': {
       'type': 'link',

--- a/src/schemas/types.js
+++ b/src/schemas/types.js
@@ -295,6 +295,15 @@ export const types = {
           '../x-oad-type': 'array'
         }
       },
+      'uniqueItems': {
+        'type': 'option',
+        'format': 'checkbox',
+        'checkboxFormat': 'simple',
+        'choices': [{'i18nKey': '/blank', 'key': ''}],
+        'conditions': {
+          '../x-oad-type': 'array'
+        }
+      },
       'properties': {
         'type': 'lazylink',
         'target': '/global-definitions/types',

--- a/src/schemas/types.js
+++ b/src/schemas/types.js
@@ -195,8 +195,7 @@ export const allOf = {
       'legendChildren/name': null,
       'legendChildren/x-oad-type/columns': 8
     }
-  },
-  'validation': ['requiredIfLegendTypeIsAllOf']
+  }
 };
 
 export const types = {
@@ -276,7 +275,8 @@ export const types = {
         'target': '/types-allof',
         'conditions': {
           '../x-oad-type': 'allOf'
-        }
+        },
+        'slightlyLessLazy': true
       },
       'type': {
         'type': 'link',

--- a/src/schemas/types.js
+++ b/src/schemas/types.js
@@ -177,7 +177,9 @@ export const types = {
     'type': 'object',
     'setValueListeners': [
       (field, newValue) => {
-        if (newValue.hasOwnProperty('$ref')) {
+        if (newValue.hasOwnProperty('allOf')) {
+          field.legendChildren['x-oad-type'].setValue('allOf');
+        } else if (newValue.hasOwnProperty('$ref')) {
           field.legendChildren['x-oad-type'].setValue('reference');
         } else if (newValue.hasOwnProperty('type')) {
           field.legendChildren['x-oad-type'].setValue(newValue.type);
@@ -200,7 +202,7 @@ export const types = {
         'format': 'dropdown',
         'choices': [
           {'key': '', 'i18nKey': 'choose'},
-          'string', 'integer', 'boolean', 'number', 'array', 'object', 'reference', 'null'
+          'string', 'integer', 'boolean', 'number', 'array', 'object', 'reference', 'allOf', 'null'
         ],
         'validation': ['required']
       },
@@ -229,6 +231,27 @@ export const types = {
         'validation': ['requiredIfLegendTypeIsReference'],
         'conditions': {
           '../x-oad-type': 'reference'
+        }
+      },
+      'allOf': {
+        'type': 'array',
+        'i18n': {
+          'path': 'form.types.allOf'
+        },
+        'item': {
+          'type': 'lazylink',
+          'target': '/global-definitions/types/:item',
+          'overrides': {
+            'i18n/overrides': {
+              'label': 'form.types.allOf.item.label'
+            },
+            'legendChildren/name': null,
+            'legendChildren/x-oad-type/columns': 8
+          }
+        },
+        'validation': ['requiredIfLegendTypeIsAllOf'],
+        'conditions': {
+          '../x-oad-type': 'allOf'
         }
       },
       'type': {

--- a/src/schemas/types.js
+++ b/src/schemas/types.js
@@ -253,6 +253,7 @@ export const types = {
         },
         'item': {
           'type': 'lazylink',
+          'slightlyLessLazy': true,
           'target': '/global-definitions/types/:item',
           'overrides': {
             'i18n/keys': {

--- a/src/schemas/types.js
+++ b/src/schemas/types.js
@@ -158,7 +158,7 @@ export const enumArray = {
 
 const enumIfHasType = Object.assign({}, enumArray);
 enumIfHasType.conditions = {
-  '../x-oad-type': ['string', 'integer', 'boolean', 'number', 'array', 'object', 'null']
+  '../x-oad-type': ['string', 'integer', 'boolean', 'number', 'array', 'null']
 };
 
 export const types = {
@@ -312,6 +312,22 @@ export const types = {
               'type': '${#/type}'
             }
           }
+        },
+        'conditions': {
+          '../x-oad-type': 'object'
+        }
+      },
+      'additionalProperties': {
+        'type': 'lazylink',
+        'target': '/global-definitions/types/:item',
+        'overrides': {
+          'i18n/keys': {
+            'label': 'form.types.item.additionalProperties.label'
+          },
+          'legendChildren/name': null,
+          'legendChildren/x-oad-type/columns': 8,
+          'legendChildren/x-oad-type/validation': [],
+          'collapsed': true
         },
         'conditions': {
           '../x-oad-type': 'object'

--- a/src/schemas/types.js
+++ b/src/schemas/types.js
@@ -235,6 +235,7 @@ export const types = {
       },
       'allOf': {
         'type': 'array',
+        'hideValueIfEmpty': false,
         'i18n': {
           'path': 'form.types.allOf'
         },

--- a/src/schemas/types.js
+++ b/src/schemas/types.js
@@ -147,6 +147,17 @@ export const enumItem = {
   }
 };
 
+const defaultValue = Object.assign({}, enumItem);
+defaultValue.i18n = {
+  'path': 'form.enum.item',
+  'keys': {
+    'label': 'form.defaultValue.label'
+  }
+};
+defaultValue.conditions = {
+  '../x-oad-type': ['string', 'integer', 'boolean', 'number', 'array', 'null']
+};
+
 export const enumArray = {
   'type': 'array',
   'i18n': {
@@ -160,6 +171,7 @@ const enumIfHasType = Object.assign({}, enumArray);
 enumIfHasType.conditions = {
   '../x-oad-type': ['string', 'integer', 'boolean', 'number', 'array', 'null']
 };
+
 
 export const types = {
   'type': 'array',
@@ -281,6 +293,7 @@ export const types = {
         'choices': typeFormatChoices
       },
       'enum': enumIfHasType,
+      'default': defaultValue,
       'readOnly': {
         'type': 'option',
         'format': 'checkbox',

--- a/src/schemas/types.js
+++ b/src/schemas/types.js
@@ -172,6 +172,27 @@ enumIfHasType.conditions = {
   '../x-oad-type': ['string', 'integer', 'boolean', 'number', 'array', 'null']
 };
 
+export const allOf = {
+  'type': 'array',
+  'hideValueIfEmpty': false,
+  'i18n': {
+    'path': 'form.types.allOf'
+  },
+  'item': {
+    'type': 'lazylink',
+    'slightlyLessLazy': true,
+    'target': '/global-definitions/types/:item',
+    'overrides': {
+      'i18n/keys': {
+        'label': 'form.types.allOf.item.label'
+      },
+      'i18n/interpolations/index': '${..:humanIndex}',
+      'legendChildren/name': null,
+      'legendChildren/x-oad-type/columns': 8
+    }
+  },
+  'validation': ['requiredIfLegendTypeIsAllOf']
+};
 
 export const types = {
   'type': 'array',
@@ -246,25 +267,8 @@ export const types = {
         }
       },
       'allOf': {
-        'type': 'array',
-        'hideValueIfEmpty': false,
-        'i18n': {
-          'path': 'form.types.allOf'
-        },
-        'item': {
-          'type': 'lazylink',
-          'slightlyLessLazy': true,
-          'target': '/global-definitions/types/:item',
-          'overrides': {
-            'i18n/keys': {
-              'label': 'form.types.allOf.item.label'
-            },
-            'i18n/interpolations/index': '${..:humanIndex}',
-            'legendChildren/name': null,
-            'legendChildren/x-oad-type/columns': 8
-          }
-        },
-        'validation': ['requiredIfLegendTypeIsAllOf'],
+        'type': 'lazylink',
+        'target': '/types-allof',
         'conditions': {
           '../x-oad-type': 'allOf'
         }

--- a/src/schemas/types.js
+++ b/src/schemas/types.js
@@ -242,9 +242,10 @@ export const types = {
           'type': 'lazylink',
           'target': '/global-definitions/types/:item',
           'overrides': {
-            'i18n/overrides': {
+            'i18n/keys': {
               'label': 'form.types.allOf.item.label'
             },
+            'i18n/interpolations/index': '${..:humanIndex}',
             'legendChildren/name': null,
             'legendChildren/x-oad-type/columns': 8
           }

--- a/src/schemas/types.js
+++ b/src/schemas/types.js
@@ -183,10 +183,15 @@ export const allOf = {
     'slightlyLessLazy': true,
     'target': '/global-definitions/types/:item',
     'overrides': {
-      'i18n/keys': {
-        'label': 'form.types.allOf.item.label'
+      'i18n': {
+        'path': 'form.types.item',
+        'keys': {
+          'label': 'form.types.allOf.item.label'
+        },
+        'interpolations': {
+          'index': '${..:humanIndex}'
+        }
       },
-      'i18n/interpolations/index': '${..:humanIndex}',
       'legendChildren/name': null,
       'legendChildren/x-oad-type/columns': 8
     }

--- a/src/schemas/types.js
+++ b/src/schemas/types.js
@@ -281,6 +281,17 @@ export const types = {
         'choices': typeFormatChoices
       },
       'enum': enumIfHasType,
+      'readOnly': {
+        'type': 'option',
+        'format': 'checkbox',
+        'checkboxFormat': 'simple',
+        'choices': [{'i18nKey': '/blank', 'key': ''}],
+        'conditions': {
+          // Check if the property this readOnly field is in is the child of a
+          // object property/definition.
+          '../../../../x-oad-type': 'object'
+        }
+      },
       'items': {
         'type': 'lazylink',
         'target': '/global-definitions/types/:item',

--- a/src/validation.js
+++ b/src/validation.js
@@ -29,16 +29,6 @@ export class Validation {
     return { valid: true };
   }
 
-  requiredIfLegendTypeIsAllOf(field) {
-    if (field.isEmpty() && field.resolveRef('../x-oad-type').getValue() === 'allOf') {
-      return {
-        valid: false,
-        error: this.i18n.tr('validation.required-is-empty')
-      };
-    }
-    return { valid: true };
-  }
-
   keyRequired(field) {
     if (field.key.length === 0) {
       return {

--- a/src/validation.js
+++ b/src/validation.js
@@ -29,6 +29,16 @@ export class Validation {
     return { valid: true };
   }
 
+  requiredIfLegendTypeIsAllOf(field) {
+    if (field.isEmpty() && field.resolveRef('../x-oad-type').getValue() === 'allOf') {
+      return {
+        valid: false,
+        error: this.i18n.tr('validation.required-is-empty')
+      };
+    }
+    return { valid: true };
+  }
+
   keyRequired(field) {
     if (field.key.length === 0) {
       return {


### PR DESCRIPTION
Fixes #275 

This pull request adds support for `allOf`, `uniqueItems`, `readOnly` and `additionalProperties` in type definitions.