### PR TITLE
Make LazyLinkfields always slightlyLessLazy

### DIFF
--- a/src/resources/elements/lazylinkfield.js
+++ b/src/resources/elements/lazylinkfield.js
@@ -116,7 +116,7 @@ export class LazyLinkfield extends Field {
     // lazy.
     const display = super.shouldDisplay();
     if (display) {
-      const isParentCollapsed = (!this.parent || !this.parent.isCollapsible || !this.parent.collapsed);
+      const isParentCollapsed = this.parent && this.parent.isCollapsible && this.parent.collapsed;
       if (this.child === undefined && !isParentCollapsed) {
         this.createChild();
       }

--- a/src/resources/elements/lazylinkfield.js
+++ b/src/resources/elements/lazylinkfield.js
@@ -12,13 +12,11 @@ export class LazyLinkfield extends Field {
   overrides = {};
   child = undefined;
   cachedValue = undefined;
-  slightlyLessLazy = false;
 
   /** @inheritdoc */
   init(id = '', args = {}) {
     this.target = args.target || '#';
     this.overrides = args.overrides || {};
-    this.slightlyLessLazy = !!args.slightlyLessLazy;
     return super.init(id, args);
   }
 
@@ -36,9 +34,7 @@ export class LazyLinkfield extends Field {
    */
   isEmpty() {
     if (!this.child) {
-      // If not slightlyLessLazy, ignore the cached value and state that the
-      // field is empty. Otherwise, check the cached value first.
-      return !this.slightlyLessLazy || !this.cachedValue;
+      return !this.cachedValue;
     }
     return this.child.isEmpty();
   }
@@ -119,8 +115,9 @@ export class LazyLinkfield extends Field {
     // appears, the child will be deleted. This is what makes this link field
     // lazy.
     const display = super.shouldDisplay();
-    if (display && (!this.parent || !this.parent.isCollapsible || !this.parent.collapsed)) {
-      if (this.child === undefined) {
+    if (display) {
+      const isParentCollapsed = (!this.parent || !this.parent.isCollapsible || !this.parent.collapsed);
+      if (this.child === undefined && !isParentCollapsed) {
         this.createChild();
       }
     } else if (this.child !== undefined) {
@@ -159,10 +156,8 @@ export class LazyLinkfield extends Field {
   getValue() {
     if (this.child) {
       return this.child.getValue();
-    } else if (this.slightlyLessLazy) {
-      return this.cachedValue;
     }
-    return undefined;
+    return this.cachedValue;
   }
 
   resolvePath(path) {

--- a/src/schemas/types.js
+++ b/src/schemas/types.js
@@ -180,7 +180,6 @@ export const allOf = {
   },
   'item': {
     'type': 'lazylink',
-    'slightlyLessLazy': true,
     'target': '/global-definitions/types/:item',
     'overrides': {
       'i18n': {
@@ -275,8 +274,7 @@ export const types = {
         'target': '/types-allof',
         'conditions': {
           '../x-oad-type': 'allOf'
-        },
-        'slightlyLessLazy': true
+        }
       },
       'type': {
         'type': 'link',


### PR DESCRIPTION
Fixes #279 

This pull request makes all `LazyLinkfield`s act the way that fields with `slightlyLessLazy` = `true` did before.