### PR TITLE
Add tag name to title of tag definitions

### DIFF
--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -256,7 +256,7 @@
     "tags": {
       "label": "Tag definitions",
       "item": {
-        "label": "Tag",
+        "label": "Tag #{{index}}: {{-name}}",
         "name": {
           "label": "Name",
           "placeholder": "e.g. user_operations"

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -255,6 +255,7 @@
     },
     "tags": {
       "label": "Tag definitions",
+      "newItemText": "New Tag",
       "item": {
         "label": "Tag #{{index}}: {{-name}}",
         "name": {

--- a/src/schemas/tags.js
+++ b/src/schemas/tags.js
@@ -6,6 +6,11 @@ export const tags = {
   'item': {
     'type': 'object',
     'label': 'Tag',
+    'i18n': {
+      'interpolations': {
+        'name': '${#/name}'
+      }
+    },
     'children': {
       'name': {
         'type': 'text',


### PR DESCRIPTION
Fixes #291 

This pull request adds the name of tags to the title of the tag definition.