### PR TITLE
Fix rich preview of invalid form when loading page

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -106,7 +106,7 @@ export class App {
   }
 
   bind() {
-    this.split(window.localStorage.split || 'split');
+    this.split(window.localStorage.split || 'split', true);
   }
 
   languageChanged() {
@@ -160,7 +160,7 @@ export class App {
           this.richPreviewErrorModal.open();
           return;
         }
-      } else {
+      } else if (this.richPreviewErrorModal) {
         this.richPreviewErrorModal.close();
       }
     }


### PR DESCRIPTION
This pull request fixes a bug that caused a crash if the user left in rich preview mode with validation errors and then tried to re-enter the editor.