### PR TITLE
Send spec directly to Swagger UI

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -127,9 +127,8 @@ export class App {
     }
 
     setTimeout(() => {
-      const url = 'data:application/json;charset=utf-8,' + encodeURIComponent(this.json);
       this.richPreview = new SwaggerUIBundle({
-        url,
+        spec: this.getFormData(),
         dom_id: '#rich-preview',
         // Disable Swagger.io online validation (AKA spyware)
         validatorUrl: null,


### PR DESCRIPTION
Fixes #294 

This pull request changes Swagger UI opening so that the spec is sent as a JS object rather than a data URL. This improves the code readability and fixes IE compatibility.