### PR TITLE
Add space between scrollbar and text in about page

### DIFF
--- a/src/style/_main.scss
+++ b/src/style/_main.scss
@@ -89,6 +89,7 @@
 
   .about {
     max-width: 45rem;
+    padding-right: 1rem;
 
     text-align: justify;
 


### PR DESCRIPTION
Fixes #312 

This pull request adds some space to the right of the about page content so if there's a scrollbar, it won't be too close to the text.

Demo available at https://dev.openapi.design/feature/about-page-ui