### PR TITLE
Make tooltips follow mouse to avoid positioning problems

### DIFF
--- a/src/resources/elements/tooltip.html
+++ b/src/resources/elements/tooltip.html
@@ -1,4 +1,4 @@
-<template mouseover.delegate="mouseover()" mouseout.delegate="mouseout()">
+<template mouseover.delegate="mouseover()" mousemove.delegate="mousemove($event)" mouseout.delegate="mouseout()">
   <slot></slot>
   <div ref="textbox" class="text hidden">${text}</div>
 </template>

--- a/src/resources/elements/tooltip.js
+++ b/src/resources/elements/tooltip.js
@@ -4,45 +4,20 @@ export class Tooltip {
   @bindable text = '';
 
   mouseover() {
-    // Make the tooltip popup visible.
-    this.textbox.style.display = 'inline-block';
-
-    const offsetTop = this.textbox.offsetTop;
-    const offsetLeft = this.textbox.offsetLeft;
-    const width = this.textbox.offsetWidth;
-    const documentWidth = document.documentElement.clientWidth;
-    const style = this.textbox.style;
-
-    // Place the tooltip popup below the info button so the right edges align.
-    style.top = offsetTop + 'px';
-    if (width > documentWidth) {
-      style.width = '100%';
-    }
-    const distanceFromRightEdge = documentWidth - (offsetLeft + width);
-    if (distanceFromRightEdge < 0) {
-      // Popup doesn't fit if it's placed on the right side of the info button,
-
-      // so place it below the info button
-      style.top = (offsetTop + this.textbox.parentNode.offsetHeight) + 'px';
-      // and to the left
-      if (style.width !== '100%') {
-        // There should be space on the left, so we can move it just enough.
-        style.transform = 'translateX(' + distanceFromRightEdge + 'px)';
-      } else {
-        // There's not enough space, so put it to the left edge.
-        style.transform = 'translateX(-' + offsetLeft + 'px)';
-      }
-    }
+    const textbox = $(this.textbox);
+    textbox.css({ display: 'inline-block' });
+    const formDiv = $('.form');
+    const body = $('body');
+    const wrapper = formDiv.css('overflow-y') === 'auto' ? formDiv : body;
+    textbox.css({
+      top: `${textbox.offset().top - wrapper.offset().top}px`
+    });
   }
 
   mouseout() {
-    this.textbox.style.display = 'none';
-    // Reset the top value so that the tooltip popup doesn't go lower each time
-    // you hover over the box.
-    this.textbox.style.top = 'auto';
-    // Reset the transform so it isn't offset to the left if the user resizes the window.
-    this.textbox.style.transform = 'none';
-    // Reset the width so it doesn't stay too wide if the user resizes the window.
-    this.textbox.style.width = '20rem';
+    $(this.textbox).css({
+      top: 'auto',
+      display: 'none'
+    });
   }
 }

--- a/src/resources/elements/tooltip.js
+++ b/src/resources/elements/tooltip.js
@@ -4,19 +4,20 @@ export class Tooltip {
   @bindable text = '';
 
   mouseover() {
-    const textbox = $(this.textbox);
-    textbox.css({ display: 'inline-block' });
-    const formDiv = $('.form');
-    const body = $('body');
-    const wrapper = formDiv.css('overflow-y') === 'auto' ? formDiv : body;
-    textbox.css({
-      top: `${textbox.offset().top - wrapper.offset().top}px`
+    $(this.textbox).css({ display: 'inline-block' });
+  }
+
+  mousemove(event) {
+    $(this.textbox).css({
+      top: `${event.clientY + 12}px`,
+      left: `${event.clientX + 12}px`
     });
   }
 
   mouseout() {
     $(this.textbox).css({
       top: 'auto',
+      left: 'auto',
       display: 'none'
     });
   }

--- a/src/style/_tooltip.scss
+++ b/src/style/_tooltip.scss
@@ -12,7 +12,7 @@ tooltip {
   }
 
   > .text {
-    position: absolute;
+    position: fixed;
 
     display: none;
 

--- a/src/style/_tooltip.scss
+++ b/src/style/_tooltip.scss
@@ -17,7 +17,8 @@ tooltip {
     display: none;
 
     box-sizing: border-box;
-    width: 20rem;
+    width: auto;
+    max-width: 20rem;
     padding: .5rem;
 
     border-radius: .25rem;


### PR DESCRIPTION
Fixes #317 

This pull request makes the tooltips follow the mouse instead of having an absolute position. This should fix all browser compatibility problems.