### PR TITLE
Fix lookup of global path param references in path definitions

### DIFF
--- a/src/validation.js
+++ b/src/validation.js
@@ -153,7 +153,14 @@ export class Validation {
       if (!paramName) {
         return undefined;
       }
-      return field.resolveRef(`/global-definitions/${paramName}`).getValue();
+
+      const globalParams = field.resolveRef('/global-definitions/parameters');
+
+      for (const arrayParam of globalParams.children) {
+        if (arrayParam.getValue().name === paramName) {
+          return arrayParam.getValue();
+        }
+      }
     };
     const isParamInArray = (paramsField, lookingForParam) => {
       for (const arrayParam of paramsField.children) {


### PR DESCRIPTION
Great project - thanks!

This is a partial fix for #354.

Steps to repro the issue:
1. With a fresh, empty spec, add a parameter to the Definitions tab
    - location should be "path"
    - name should be "test"
1. Add a path which includes the param in it - e.g. "/{test}"
1. Start filling out a method for the path - e.g. add a description to the "get" method
1. Add a parameter with a type of "reference" to the method and select the "test" parameter
1. In the Javascript console, note the exception raised as a result of [this line](https://github.com/apinf/openapi-designer/blob/master/src/validation.js#L156) (attempting to call `getValue()` on `undefined`)

Alternatively, just use [this spec](https://gist.github.com/carlevans719/9e4f3f1c1282c98f2fee06681f4f9a03).

This patch changes the behaviour of the `parseParamRef` function. First it grabs the "Parameters" field. Then it iterates over the child fields (which are parameter definitions) and it returns as soon as it finds one which matches the name in the path.

I noticed that the path is still flagged as invalid if the parameter reference is added _after_ the path is set but it works the other way round (adding the parameter _then_ changing the path) so I think there's somewhere else I need to tweak too but I'm not sure where it is. Any pointers would be really appreciated!